### PR TITLE
Don't re-write root logger log level

### DIFF
--- a/src/yatter/constants.py
+++ b/src/yatter/constants.py
@@ -238,4 +238,4 @@ YARRRML_DATABASES_DRIVER = {
 }
 
 logger = logging.getLogger(__name__)
-coloredlogs.install(level='DEBUG', fmt='%(asctime)s,%(msecs)03d | %(levelname)s: %(message)s')
+coloredlogs.install(level='DEBUG', fmt='%(asctime)s,%(msecs)03d | %(levelname)s: %(message)s', logger=logger)


### PR DESCRIPTION
Currently the way that constants.py installs coloredlogs causes it to override the root logger to DEBUG, as well as enabling coloredlogs on the root logger, which can be undesirable. To fix that, instead we pass the (already created) logger instance into the install command, so that only log levels and coloring for that logger are modified.